### PR TITLE
Restrict Femto metadata to the current major version of fluent-ui/react

### DIFF
--- a/Fable.FluentUI.fsproj
+++ b/Fable.FluentUI.fsproj
@@ -11,10 +11,10 @@
 
   <PropertyGroup>
     <NpmDependencies>
-      <NpmPackage Name="@fluentui/react" Version="&gt;= 8.11.2" ResolutionStrategy="Max" />
-      <NpmPackage Name="@fluentui/date-time-utilities" Version="&gt;= 8.0.2" ResolutionStrategy="Max" />
-      <NpmPackage Name="@fluentui/react-focus" Version="&gt;= 8.0.7" ResolutionStrategy="Max" />
-      <NpmPackage Name="@fluentui/react-icons" Version="&gt;= 1.1.118" ResolutionStrategy="Max" />
+      <NpmPackage Name="@fluentui/react" Version="&gt;= 8.11.2 &lt; 9.0.0" ResolutionStrategy="Max" />
+      <NpmPackage Name="@fluentui/date-time-utilities" Version="&gt;= 8.0.2 &lt; 9.0.0" ResolutionStrategy="Max" />
+      <NpmPackage Name="@fluentui/react-focus" Version="&gt;= 8.0.7 &lt; 9.0.0" ResolutionStrategy="Max" />
+      <NpmPackage Name="@fluentui/react-icons" Version="&gt;= 1.1.118 &lt; 2.0.0" ResolutionStrategy="Max" />
     </NpmDependencies>
   </PropertyGroup>
     


### PR DESCRIPTION
When you use 
```xml
<NpmPackage Name="@fluentui/react" Version="&gt;= 8.11.2" ResolutionStrategy="Max" />
```
Femto will search the available packages of `@fluentui/react`. Filters those that satisfy the `>= 8.11.2` and chooses the highest version because the resolution strategy is set to `Max`. 

This can be problematic when a new _major_ version of `@fluentui/react` comes out (i.e. `9.0.0`) with potentially many breaking changes because Femto will pick the latest of the latest. 

You can solve this by either setting the resolution strategy to `Min` in which case the version 8.11.2 will _always_ be resolved and users won't get unexpected breaking changes. However, the users will miss out on versions in the 8.x.y range higher than 8.11.2 which are usually bug fixes or added features. 

The optimal configuration for Femto to take is where the range is `8.11.2 >= version > 9.0.0` and resolution strategy is set to `Max` like what I did in this PR so that even if a new major version of fluentui comes out, it won't be automatically resolved until this binding is updated and if there are bug fixes (say in 8.12.0) then those will be resolved because of the `Max` resolution strategy